### PR TITLE
content: add newsletter issue #1 launch announcement

### DIFF
--- a/templates/newsletter/issue-001-launch.md
+++ b/templates/newsletter/issue-001-launch.md
@@ -1,0 +1,66 @@
+# Newsletter Issue #1 — Launch Announcement
+
+**Subject Line:** The AI tools your marketing team actually needs
+**Preview Text:** A curated directory + a free cheat sheet to skip the hype cycle
+
+---
+
+## Welcome to the AI Tools Directory
+
+You don't need another listicle of 200 AI tools you'll never try.
+
+You need the right ones — vetted, categorized, and explained in plain language so you can actually make a decision.
+
+That's what the **AI Tools Directory** is. We review AI tools across 11 categories — from marketing and analytics to coding and design — with real ratings, honest pros/cons, and pricing you can find without signing up for a demo.
+
+Whether you're a marketing manager exploring AI for the first time or an ops lead looking to automate reporting, this is the starting point that respects your time.
+
+👉 **[Browse the Directory →](https://aitoolsdirectory.co)**
+
+---
+
+## 🔦 Tool Spotlight
+
+**Surfer SEO** — *Content optimization, powered by data*
+If your team produces blog content and you're guessing at keywords, Surfer takes the guesswork out. It analyzes top-ranking pages and gives you a real-time content score as you write. Starts at $89/mo, but pays for itself fast if organic is a channel you care about.
+
+**HubSpot AI** — *AI built into a platform you probably already use*
+HubSpot has been quietly shipping AI features into their CRM, email, and content tools. If you're already on HubSpot, the AI layer (content generation, predictive lead scoring, workflow suggestions) is worth turning on. Freemium — the AI features roll in with existing plans.
+
+---
+
+## 🛠️ New: UTM Builder for Marketing Teams
+
+Tired of messy UTM links and inconsistent campaign tracking? We built a simple, practical UTM Builder designed for marketing teams who need clean data in Google Analytics.
+
+- Consistent naming conventions across your team
+- Pre-built templates for common campaign types
+- Copy-paste ready links in seconds
+
+**$19 one-time purchase.** No subscription, no bloat.
+
+👉 **[Get the UTM Builder →](https://aitoolsdirectory.gumroad.com/l/utm-builder)**
+
+---
+
+## 🎁 Free: The Marketing AI Cheat Sheet
+
+Not sure where AI fits into your workflow? Start here. This one-page cheat sheet maps AI tools to common marketing tasks — content, analytics, ads, email, and more.
+
+No email course. No 47-page ebook. Just a useful reference you'll actually keep open.
+
+👉 **[Download the Cheat Sheet (Free) →](https://aitoolsdirectory.co/lead-magnets/marketing-ai-cheat-sheet.pdf)**
+
+---
+
+## What's Next
+
+We're adding new tools and categories every week. Upcoming issues will cover:
+
+- AI tools for marketing analytics (the ones worth paying for)
+- How to build a basic AI workflow without writing code
+- Tool deep-dives with real use cases
+
+Hit reply if there's a tool or category you want us to cover. We read everything.
+
+— The AI Tools Directory Team


### PR DESCRIPTION
Adds the first newsletter issue for the AI Tools Directory launch.

## What's included
- Subject line + preview text optimized for opens
- Welcome section introducing the directory
- Tool spotlight: Surfer SEO and HubSpot AI
- CTA for UTM Builder ($19 on Gumroad)
- CTA for free Marketing AI Cheat Sheet lead magnet
- Preview of upcoming newsletter topics

Saved as `templates/newsletter/issue-001-launch.md` — ready to paste into Beehiiv.

Closes #20