### PR TITLE
feat: Wire up Beehiiv subscriber API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,18 @@
+# =============================================================================
 # Beehiiv Newsletter Integration
+# =============================================================================
+# Required for the /api/subscribe endpoint.
 # Get these from: beehiiv.com → Settings → API
+#
+# BEEHIIV_API_KEY: Your Beehiiv API key (starts with "bh_")
+# BEEHIIV_PUBLICATION_ID: Your publication ID (starts with "pub_")
+#
 BEEHIIV_API_KEY=your_api_key_here
 BEEHIIV_PUBLICATION_ID=pub_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
-# Gumroad Store Integration  
+# =============================================================================
+# Gumroad Store Integration
+# =============================================================================
 # Get these from: gumroad.com → Dashboard → Product page
 GUMROAD_USERNAME=aitoolsdir
 GUMROAD_PRODUCT_CHEATSHEET=your_product_short_code

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,9 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
+import node from "@astrojs/node";
 
 export default defineConfig({
   integrations: [tailwind()],
   site: "https://aitoolsdirectory.com",
+  adapter: node({ mode: "standalone" }),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@astrojs/node": "^9.5.5",
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^5.0.0",
         "tailwindcss": "^3.4.19"
@@ -65,6 +66,20 @@
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/node": {
+      "version": "9.5.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/node/-/node-9.5.5.tgz",
+      "integrity": "sha512-rtU2BGU5u3SfGURpANfMxVzCIoR86MkaN05ncza9rbtuMKJ/XnRJt/BbyVknDbOJ71hoci0SIsJwKcJR8vvi/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.7.6",
+        "send": "^1.2.1",
+        "server-destroy": "^1.0.1"
+      },
+      "peerDependencies": {
+        "astro": "^5.17.3"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -2350,6 +2365,15 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2503,6 +2527,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.330",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.330.tgz",
@@ -2514,6 +2544,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2583,6 +2622,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -2602,6 +2647,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/eventemitter3": {
@@ -2723,6 +2777,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -3006,6 +3069,26 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -3015,6 +3098,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
@@ -4076,6 +4165,31 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -4215,6 +4329,18 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
@@ -4566,6 +4692,15 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -4945,6 +5080,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -5041,6 +5214,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-width": {
@@ -5258,6 +5440,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -5321,20 +5512,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/ufo": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/daldc/ai-tools-directory#readme",
   "dependencies": {
+    "@astrojs/node": "^9.5.5",
     "@astrojs/tailwind": "^6.0.2",
     "astro": "^5.0.0",
     "tailwindcss": "^3.4.19"

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -1,8 +1,20 @@
 ---
+/**
+ * Newsletter — inline newsletter signup that POSTs to /api/subscribe (Beehiiv).
+ *
+ * Props:
+ *   utmSource  — override the default UTM source tag (default: "ai_tools_directory")
+ *   utmCampaign — override the default UTM campaign tag (default: "signup_form")
+ */
+interface Props {
+  utmSource?: string;
+  utmCampaign?: string;
+}
 
+const { utmSource = "ai_tools_directory", utmCampaign = "signup_form" } = Astro.props;
 ---
 
-<section class="relative overflow-hidden">
+<section class="relative overflow-hidden" data-utm-source={utmSource} data-utm-campaign={utmCampaign}>
   <div class="absolute inset-0 bg-gradient-to-br from-brand-teal/5 via-transparent to-brand-amber/5 rounded-3xl"></div>
   <div class="relative border border-surface-700/50 rounded-3xl p-8 md:p-12">
     <div class="max-w-2xl mx-auto text-center">
@@ -13,19 +25,95 @@
         Get weekly updates on the best new AI tools, tips for marketers, and exclusive guides delivered to your inbox.
       </p>
 
-      <div id="beehiiv-embed" class="max-w-md mx-auto">
-        <form class="flex gap-3" onsubmit="return false;">
+      <div class="max-w-md mx-auto">
+        <!-- Signup form -->
+        <form id="newsletter-inline-form" class="flex gap-3">
           <input
             type="email"
+            name="email"
             placeholder="your@email.com"
+            required
             class="flex-1 px-4 py-3 rounded-xl bg-surface-800 border border-surface-700 text-white placeholder-zinc-600 text-sm focus:outline-none focus:border-brand-teal/50 focus:ring-1 focus:ring-brand-teal/20 transition-all"
           />
-          <button type="submit" class="btn-primary whitespace-nowrap">
+          <button
+            type="submit"
+            id="newsletter-inline-btn"
+            class="btn-primary whitespace-nowrap"
+          >
             Subscribe
           </button>
         </form>
-        <p class="text-zinc-600 text-xs mt-3">Free forever. No spam. Unsubscribe anytime.</p>
+        <p id="newsletter-inline-hint" class="text-zinc-600 text-xs mt-3">Free forever. No spam. Unsubscribe anytime.</p>
+
+        <!-- Success state -->
+        <div id="newsletter-inline-success" class="hidden">
+          <div class="flex items-center justify-center gap-2 text-brand-teal">
+            <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
+              <polyline points="22 4 12 14.01 9 11.01"></polyline>
+            </svg>
+            <span class="font-medium">You're in! Check your inbox.</span>
+          </div>
+        </div>
+
+        <!-- Error state -->
+        <div id="newsletter-inline-error" class="hidden mt-2">
+          <p class="text-red-400 text-xs"></p>
+        </div>
       </div>
     </div>
   </div>
 </section>
+
+<script is:inline>
+(function () {
+  const form = document.getElementById("newsletter-inline-form");
+  if (!form) return;
+
+  const section = form.closest("section");
+  const utmSource = section?.dataset.utmSource || "ai_tools_directory";
+  const utmCampaign = section?.dataset.utmCampaign || "signup_form";
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const email = form.querySelector('input[name="email"]').value;
+    const btn = document.getElementById("newsletter-inline-btn");
+    const hint = document.getElementById("newsletter-inline-hint");
+    const success = document.getElementById("newsletter-inline-success");
+    const errorEl = document.getElementById("newsletter-inline-error");
+    const errorMsg = errorEl?.querySelector("p");
+
+    btn.disabled = true;
+    btn.textContent = "Subscribing...";
+    errorEl.classList.add("hidden");
+
+    try {
+      const res = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          utm_source: utmSource,
+          utm_medium: "website",
+          utm_campaign: utmCampaign,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (res.ok) {
+        form.classList.add("hidden");
+        hint.classList.add("hidden");
+        success.classList.remove("hidden");
+      } else {
+        throw new Error(data.error || "Signup failed");
+      }
+    } catch (err) {
+      errorMsg.textContent = err.message || "Something went wrong. Please try again.";
+      errorEl.classList.remove("hidden");
+      btn.disabled = false;
+      btn.textContent = "Subscribe";
+    }
+  });
+})();
+</script>

--- a/src/components/NewsletterSignup.astro
+++ b/src/components/NewsletterSignup.astro
@@ -1,15 +1,15 @@
 ---
 /**
  * NewsletterSignup — Beehiiv-powered email signup component.
- * 
+ *
  * Two modes:
- *   1. Iframe embed (default) — paste your Beehiiv embed URL, zero backend needed
- *   2. Custom form — better UX, requires API proxy (see docs/beehiiv-setup-guide.md)
- * 
+ *   1. Iframe embed — paste your Beehiiv embed URL, zero backend needed
+ *   2. Custom form (default) — better UX, uses /api/subscribe proxy
+ *
  * Usage:
  *   <NewsletterSignup />
  *   <NewsletterSignup embedUrl="https://embeds.beehiiv.com/your-id" />
- *   <NewsletterSignup mode="custom" />
+ *   <NewsletterSignup utmSource="gumroad" utmCampaign="cheatsheet_upsell" />
  */
 interface Props {
   mode?: "embed" | "custom";
@@ -17,20 +17,24 @@ interface Props {
   heading?: string;
   subheading?: string;
   compact?: boolean;
+  utmSource?: string;
+  utmCampaign?: string;
 }
 
 const {
-  mode = "embed",
+  mode = "custom",
   embedUrl = "",
   heading = "Stay ahead of the curve",
   subheading = "Get weekly updates on the best new AI tools, tips for marketers, and exclusive guides delivered to your inbox.",
   compact = false,
+  utmSource = "ai_tools_directory",
+  utmCampaign = "signup_form",
 } = Astro.props;
 
-const hasEmbed = embedUrl.length > 0;
+const hasEmbed = mode === "embed" && embedUrl.length > 0;
 ---
 
-<section class="relative overflow-hidden">
+<section class="relative overflow-hidden" data-utm-source={utmSource} data-utm-campaign={utmCampaign}>
   <div class="absolute inset-0 bg-gradient-to-br from-brand-teal/5 via-transparent to-brand-amber/5 rounded-3xl"></div>
   <div class="relative border border-surface-700/50 rounded-3xl p-8 md:p-12">
     <div class="max-w-2xl mx-auto text-center">
@@ -45,8 +49,7 @@ const hasEmbed = embedUrl.length > 0;
         </>
       )}
 
-      {mode === "embed" && hasEmbed ? (
-        <!-- Beehiiv iframe embed — replace embedUrl with your real one -->
+      {hasEmbed ? (
         <div class="newsletter-embed max-w-md mx-auto">
           <iframe
             src={embedUrl}
@@ -59,9 +62,8 @@ const hasEmbed = embedUrl.length > 0;
           ></iframe>
         </div>
       ) : (
-        <!-- Custom form fallback — works without Beehiiv embed URL -->
-        <div id="newsletter-form-container" class="max-w-md mx-auto">
-          <form id="newsletter-form" class="flex gap-3">
+        <div class="newsletter-signup-container max-w-md mx-auto">
+          <form class="newsletter-signup-form flex gap-3">
             <input
               type="email"
               name="email"
@@ -71,16 +73,14 @@ const hasEmbed = embedUrl.length > 0;
             />
             <button
               type="submit"
-              id="newsletter-submit"
-              class="btn-primary whitespace-nowrap"
+              class="newsletter-signup-btn btn-primary whitespace-nowrap"
             >
               Subscribe
             </button>
           </form>
-          <p class="text-zinc-600 text-xs mt-3">Free forever. No spam. Unsubscribe anytime.</p>
+          <p class="newsletter-signup-hint text-zinc-600 text-xs mt-3">Free forever. No spam. Unsubscribe anytime.</p>
 
-          <!-- Success state (hidden by default) -->
-          <div id="newsletter-success" class="hidden">
+          <div class="newsletter-signup-success hidden">
             <div class="flex items-center justify-center gap-2 text-brand-teal">
               <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
@@ -90,9 +90,8 @@ const hasEmbed = embedUrl.length > 0;
             </div>
           </div>
 
-          <!-- Error state (hidden by default) -->
-          <div id="newsletter-error" class="hidden mt-2">
-            <p class="text-red-400 text-xs">Something went wrong. Please try again.</p>
+          <div class="newsletter-signup-error hidden mt-2">
+            <p class="text-red-400 text-xs"></p>
           </div>
         </div>
       )}
@@ -101,41 +100,54 @@ const hasEmbed = embedUrl.length > 0;
 </section>
 
 <script is:inline>
-  // Custom form handler — connects to Beehiiv API via your serverless proxy
-  // Replace PROXY_URL with your API endpoint (e.g., /api/subscribe or a Netlify/Vercel function)
-  const PROXY_URL = "/api/subscribe"; 
-
-  const form = document.getElementById("newsletter-form");
-  if (form) {
-    form.addEventListener("submit", async (e) => {
+(function () {
+  document.querySelectorAll(".newsletter-signup-form").forEach(function (form) {
+    form.addEventListener("submit", async function (e) {
       e.preventDefault();
+      const container = form.closest(".newsletter-signup-container");
+      const section = form.closest("section");
+      const utmSource = section?.dataset.utmSource || "ai_tools_directory";
+      const utmCampaign = section?.dataset.utmCampaign || "signup_form";
+
       const email = form.querySelector('input[name="email"]').value;
-      const btn = document.getElementById("newsletter-submit");
-      const success = document.getElementById("newsletter-success");
-      const error = document.getElementById("newsletter-error");
+      const btn = container.querySelector(".newsletter-signup-btn");
+      const hint = container.querySelector(".newsletter-signup-hint");
+      const success = container.querySelector(".newsletter-signup-success");
+      const errorEl = container.querySelector(".newsletter-signup-error");
+      const errorMsg = errorEl?.querySelector("p");
 
       btn.disabled = true;
       btn.textContent = "Subscribing...";
-      error.classList.add("hidden");
+      errorEl.classList.add("hidden");
 
       try {
-        const res = await fetch(PROXY_URL, {
+        const res = await fetch("/api/subscribe", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email }),
+          body: JSON.stringify({
+            email,
+            utm_source: utmSource,
+            utm_medium: "website",
+            utm_campaign: utmCampaign,
+          }),
         });
+
+        const data = await res.json();
 
         if (res.ok) {
           form.classList.add("hidden");
+          if (hint) hint.classList.add("hidden");
           success.classList.remove("hidden");
         } else {
-          throw new Error("Failed");
+          throw new Error(data.error || "Signup failed");
         }
       } catch (err) {
-        error.classList.remove("hidden");
+        if (errorMsg) errorMsg.textContent = err.message || "Something went wrong. Please try again.";
+        errorEl.classList.remove("hidden");
         btn.disabled = false;
         btn.textContent = "Subscribe";
       }
     });
-  }
+  });
+})();
 </script>

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -1,28 +1,35 @@
 /**
  * Newsletter Subscribe API Endpoint
- * 
+ *
  * Proxies signup requests to Beehiiv's API, keeping the API key server-side.
- * 
+ *
  * SETUP:
  *   1. Set BEEHIIV_API_KEY and BEEHIIV_PUBLICATION_ID in your environment variables
  *   2. In Astro, add these to your .env file:
  *      BEEHIIV_API_KEY=your_api_key_here
  *      BEEHIIV_PUBLICATION_ID=pub_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
- * 
- * NOTE: This requires Astro SSR mode or hybrid rendering.
- *       If using static output, use the Beehiiv iframe embed instead.
+ *
+ * NOTE: This endpoint runs server-side via Astro hybrid mode + @astrojs/node adapter.
  */
 
 import type { APIRoute } from "astro";
 
-export const POST: APIRoute = async ({ request }) => {
-  try {
-    const { email } = await request.json();
+export const prerender = false;
 
-    if (!email || !email.includes("@")) {
+export const POST: APIRoute = async ({ request }) => {
+  const headers = {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+  };
+
+  try {
+    const body = await request.json();
+    const { email, utm_source, utm_medium, utm_campaign } = body;
+
+    if (!email || typeof email !== "string" || !email.includes("@")) {
       return new Response(JSON.stringify({ error: "Valid email required" }), {
         status: 400,
-        headers: { "Content-Type": "application/json" },
+        headers,
       });
     }
 
@@ -31,10 +38,10 @@ export const POST: APIRoute = async ({ request }) => {
 
     if (!apiKey || !pubId) {
       console.error("Missing BEEHIIV_API_KEY or BEEHIIV_PUBLICATION_ID env vars");
-      return new Response(JSON.stringify({ error: "Newsletter service not configured" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ error: "Newsletter service not configured" }),
+        { status: 500, headers }
+      );
     }
 
     const response = await fetch(
@@ -46,11 +53,12 @@ export const POST: APIRoute = async ({ request }) => {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          email,
+          email: email.trim().toLowerCase(),
           reactivate_existing: true,
           send_welcome_email: true,
-          utm_source: "website",
-          utm_medium: "signup_form",
+          utm_source: utm_source || "ai_tools_directory",
+          utm_medium: utm_medium || "website",
+          utm_campaign: utm_campaign || "signup_form",
         }),
       }
     );
@@ -58,21 +66,37 @@ export const POST: APIRoute = async ({ request }) => {
     if (!response.ok) {
       const errorBody = await response.text();
       console.error("Beehiiv API error:", response.status, errorBody);
-      return new Response(JSON.stringify({ error: "Signup failed" }), {
+      return new Response(JSON.stringify({ error: "Signup failed. Please try again." }), {
         status: 502,
-        headers: { "Content-Type": "application/json" },
+        headers,
       });
     }
 
-    return new Response(JSON.stringify({ success: true }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    const data = await response.json();
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: "You're subscribed! Check your inbox.",
+      }),
+      { status: 200, headers }
+    );
   } catch (err) {
     console.error("Subscribe endpoint error:", err);
     return new Response(JSON.stringify({ error: "Internal error" }), {
       status: 500,
-      headers: { "Content-Type": "application/json" },
+      headers,
     });
   }
+};
+
+/** Handle CORS preflight */
+export const OPTIONS: APIRoute = async () => {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
 };


### PR DESCRIPTION
## Summary

Wire up the Beehiiv subscriber API so newsletter signup forms actually work.

### Changes

- **API Route** (`/api/subscribe`): Server-side proxy to Beehiiv subscriptions API. Keeps API key secret, validates email, normalizes input, returns proper error responses. Includes CORS preflight handler.
- **@astrojs/node adapter**: Added to enable server-side rendering for the API route (pages remain statically prerendered).
- **Newsletter.astro**: Rewired from a dead `onsubmit="return false;"` form to a working integration that POSTs to `/api/subscribe` with loading/success/error states.
- **NewsletterSignup.astro**: Updated with configurable UTM props (`utmSource`, `utmCampaign`) for tracking subscriber source (directory vs gumroad vs other). Defaults to custom form mode instead of embed.
- **UTM tracking**: All signup forms pass `utm_source`, `utm_medium`, and `utm_campaign` to Beehiiv for subscriber attribution.
- **.env.example**: Added detailed docs for `BEEHIIV_API_KEY` and `BEEHIIV_PUBLICATION_ID`.

### Setup Required

1. Add `BEEHIIV_API_KEY` and `BEEHIIV_PUBLICATION_ID` to your `.env`
2. Deploy with Node.js adapter (the API route needs server-side execution)

### Testing

- Build passes: `npx astro build` ✅
- All static pages prerender as before
- API route is server-rendered only

Closes #28